### PR TITLE
new CCC e.V. address

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@ var organisations = {
 	2:{
 		"name":"Chaos Computer Club e.V.",
 		"appendix":"Mitgliederverwaltung",
-		"address":"Postfach 76 21 66",
-		"city":"D-22069 Hamburg",
+		"address":"Zeiseweg 9",
+		"city":"D-22765 Hamburg",
 		"email":"office@ccc.de"
 	}
 }


### PR DESCRIPTION
That address is way out of date. No wonder I never saw these PDFs coming in at office@ccc.de
